### PR TITLE
Reset selected rows & selected rows can be passed from outside

### DIFF
--- a/addon/components/data-table.js
+++ b/addon/components/data-table.js
@@ -16,7 +16,7 @@ export default Ember.Component.extend({
   selectionChanged:Ember.K,
   classNames:['contextual-data-table'],
 
-  selectedRows:Ember.computed({
+  selectedRows:Ember.computed('data',{
     get(){
       return Ember.A();
     },

--- a/addon/components/data-table.js
+++ b/addon/components/data-table.js
@@ -16,10 +16,18 @@ export default Ember.Component.extend({
   selectionChanged:Ember.K,
   classNames:['contextual-data-table'],
 
-  init(){
-    this._super(...arguments);
-    this.set('selectedRows',Ember.makeArray());
-  },
+  selectedRows:Ember.computed({
+    get(){
+      return Ember.A();
+    },
+    set(key, value){
+      let arr = Ember.A();
+      if(Ember.isArray(value)){
+        arr.pushObjects(value);
+      }
+      return arr;
+    }
+  }),
 
   actions:{
     selected:function(row){

--- a/addon/components/data-table.js
+++ b/addon/components/data-table.js
@@ -16,7 +16,7 @@ export default Ember.Component.extend({
   selectionChanged:Ember.K,
   classNames:['contextual-data-table'],
 
-  selectedRows:Ember.computed('data',{
+  selectedRows:Ember.computed('data.[]',{
     get(){
       return Ember.A();
     },

--- a/tests/integration/components/data-table-test.js
+++ b/tests/integration/components/data-table-test.js
@@ -137,6 +137,21 @@ test('clear selectedRows after data has changed', function(assert) {
   assert.notOk(this.$("input[type='checkbox']:eq(3)").prop('checked'));
   assert.notOk(this.$("input[type='checkbox']:eq(4)").prop('checked'));
   assert.notOk(this.$("input[type='checkbox']:eq(5)").prop('checked'));
+
+  this.$("input[type='checkbox']:eq(3)").prop('checked', true);
+  this.$("input[type='checkbox']:eq(3)").change();
+  assert.equal(selectionCount, 1);
+
+  Ember.run(()=> {
+    newData.clear();
+    newData.pushObjects(players);
+  });
+  assert.notOk(this.$("input[type='checkbox']:eq(0)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(1)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(2)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(3)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(4)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(5)").prop('checked'));
 });
 
 

--- a/tests/integration/components/data-table-test.js
+++ b/tests/integration/components/data-table-test.js
@@ -101,6 +101,45 @@ test('renders custom header and footer', function(assert) {
 });
 
 
+test('clear selectedRows after data has changed', function(assert) {
+  var selectionCount = 0;
+  this.on('selectionChanged', function(selectedRows){
+    selectionCount=selectedRows.length;
+  });
+  this.set('data', players);
+
+  this.render(hbs`
+    {{#data-table data=data showFooter=true selectionMode='multi' selectionChanged=(action 'selectionChanged') as |t|}}
+      {{t.selectionColumn}}
+      {{t.column propertyName='name' name='Name'}}
+      {{t.column propertyName='surname' name='Surname'}}
+      {{t.column propertyName='age' name='Age'}}
+      {{t.column propertyName='nationality' name='Nationality'}}
+    {{/data-table}}
+  `);
+
+  assert.equal(selectionCount, 0);
+
+  this.$("input[type='checkbox']:eq(3)").prop('checked', true);
+  this.$("input[type='checkbox']:eq(3)").change();
+  assert.equal(selectionCount, 1);
+
+  this.$("input[type='checkbox']:eq(2)").prop('checked', true);
+  this.$("input[type='checkbox']:eq(2)").change();
+  assert.equal(selectionCount, 2);
+
+  let newData = Ember.A();
+  newData.pushObjects(players);
+  this.set('data', newData);
+  assert.notOk(this.$("input[type='checkbox']:eq(0)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(1)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(2)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(3)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(4)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(5)").prop('checked'));
+});
+
+
 test('selectedRows are managed from user of data-table', function(assert) {
   var parentSelectedRows = [players[0], players[2]];
   var resultOfSelection = [];

--- a/tests/integration/components/data-table-test.js
+++ b/tests/integration/components/data-table-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -8,6 +9,14 @@ var selcuk = {name:'Selcuk', surname: 'Inan', age:31, nationality: 'Turkish'};
 var chedjou = {name:'Aurélien', surname:'Chedjou', age:31, nationality:'Cameroonian'};
 
 var players = [sneijder, podolski, muslera, selcuk, chedjou];
+
+function assertPlayer(assert,index,player) {
+  assert.equal(this.$(`tr:eq(${index})`).find("td:eq(1)").text().trim(), player['name']);
+  assert.equal(this.$(`tr:eq(${index})`).find("td:eq(2)").text().trim(), player['surname']);
+  assert.equal(this.$(`tr:eq(${index})`).find("td:eq(3)").text().trim(), player['age']);
+  assert.equal(this.$(`tr:eq(${index})`).find("td:eq(4)").text().trim(), player['nationality']);
+}
+
 
 moduleForComponent('data-table', 'Integration | Component | data table', {
   integration: true
@@ -91,9 +100,68 @@ test('renders custom header and footer', function(assert) {
   assert.equal(this.$("li").length, 4);
 });
 
-function assertPlayer(assert,index,player) {
-  assert.equal(this.$(`tr:eq(${index})`).find("td:eq(1)").text().trim(), player['name']);
-  assert.equal(this.$(`tr:eq(${index})`).find("td:eq(2)").text().trim(), player['surname']);
-  assert.equal(this.$(`tr:eq(${index})`).find("td:eq(3)").text().trim(), player['age']);
-  assert.equal(this.$(`tr:eq(${index})`).find("td:eq(4)").text().trim(), player['nationality']);
-}
+
+test('selectedRows are managed from user of data-table', function(assert) {
+  var parentSelectedRows = [players[0], players[2]];
+  var resultOfSelection = [];
+
+  this.set('data', players);
+  this.set('parentSelectedRows', parentSelectedRows);
+  this.on('selectionChanged', function(selectedRows){
+    resultOfSelection = selectedRows;
+  });
+
+  this.render(hbs`
+    {{#data-table data=data showFooter=true selectionMode='multi' selectionChanged=(action 'selectionChanged') 
+          selectedRows=parentSelectedRows as |t|}}
+      {{t.selectionColumn}}
+      {{t.column propertyName='name' name='Name'}}
+      {{t.column propertyName='surname' name='Surname'}}
+      {{t.column propertyName='age' name='Age'}}
+      {{t.column propertyName='nationality' name='Nationality'}}
+    {{/data-table}}
+  `);
+
+  assert.equal(parentSelectedRows.length, 2);
+
+  this.$("input[type='checkbox']:eq(3)").prop('checked', true);
+  this.$("input[type='checkbox']:eq(3)").change();
+  assert.equal(parentSelectedRows.length, 2);
+  assert.equal(resultOfSelection.length, 3);
+
+  this.$("input[type='checkbox']:eq(0)").prop('checked', false);
+  this.$("input[type='checkbox']:eq(0)").change();
+  assert.equal(resultOfSelection.length, 0);
+
+  this.$("input[type='checkbox']:eq(0)").prop('checked', true);
+  this.$("input[type='checkbox']:eq(0)").change();
+  assert.equal(resultOfSelection.length, players.length);
+
+  this.set('parentSelectedRows', [players[1]]);
+  assert.notOk(this.$("input[type='checkbox']:eq(0)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(1)").prop('checked'));
+  assert.ok(this.$("input[type='checkbox']:eq(2)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(3)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(4)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(5)").prop('checked'));
+
+  this.set('parentSelectedRows', [players[1], players[3]]);
+  assert.notOk(this.$("input[type='checkbox']:eq(0)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(1)").prop('checked'));
+  assert.ok(this.$("input[type='checkbox']:eq(2)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(3)").prop('checked'));
+  assert.ok(this.$("input[type='checkbox']:eq(4)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(5)").prop('checked'));
+
+
+  let newData = Ember.A();
+  newData.pushObjects(players);
+  this.set('data', newData);
+  this.set('parentSelectedRows', []);
+  assert.notOk(this.$("input[type='checkbox']:eq(0)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(1)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(2)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(3)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(4)").prop('checked'));
+  assert.notOk(this.$("input[type='checkbox']:eq(5)").prop('checked'));
+});


### PR DESCRIPTION
Solved https://github.com/tubitak-bilgem-yte/ember-contextual-table/issues/2, by reseting selectedRows after data has changed.

Also selectedRows can be passed by the user of data-table. (In this case, selectedRows should always be managed by the user.)