### PR TITLE
Use closure actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In this example; a selection column along with 4 other columns are declared so a
         {{#if col.body}}
             <button class="btn btn-primary" data-toggle="button" 
                 aria-pressed="false" autocomplete="off"
-                {{action col.change (if col.isRowSelected false true)}} value={{col.isRowSelected}}>
+                onclick={{action col.change (if col.isRowSelected false true)}} value={{col.isRowSelected}}>
                 {{if col.isRowSelected 'Selected' 'Not Selected'}}
             </button>
         {{/if}}

--- a/addon/templates/data-table.hbs
+++ b/addon/templates/data-table.hbs
@@ -17,7 +17,7 @@
 {{/if}}
 <tbody>
 {{#each data as |row index|}}
-    <tr id={{concat rowIdPrefix '-' index}} class={{if (array-contains selectedRows row) 'contextual-table-selected-row contextual-table-row' 'contextual-table-row'}} {{action (if (array-contains selectedRows row) 'deselected' 'selected') row on='doubleClick'}}>
+    <tr id={{concat rowIdPrefix '-' index}} class={{if (array-contains selectedRows row) 'contextual-table-selected-row contextual-table-row' 'contextual-table-row'}}  ondblclick={{action (if (array-contains selectedRows row) 'deselected' 'selected') row}}>
       {{yield (hash
         column=(component 'dt-column-cell' row=row rowIndex=index)
         filterableColumn=(component 'dt-column-cell' row=row rowIndex=index)

--- a/addon/templates/pager-component.hbs
+++ b/addon/templates/pager-component.hbs
@@ -1,6 +1,6 @@
 <nav>
     <ul class="pager">
-        <li class={{previousButtonClass}}><a href="#" {{action 'previous' on='click'}}>
+        <li class={{previousButtonClass}}><a href="#" onclick={{action 'previous'}}>
             {{#if hasBlock}}
                 {{yield (hash previous=true)}}
             {{else}}
@@ -10,7 +10,7 @@
         {{#if currentPage}}
             <li class='disabled'><a href='javascript:void(0)'>{{currentPage}}</a></li>
         {{/if}}
-        <li class={{nextButtonClass}}><a href="#" {{action 'next' on='click'}}>
+        <li class={{nextButtonClass}}><a href="#" onclick={{action 'next'}}>
             {{#if hasBlock}}
                 {{yield (hash next=true)}}
             {{else}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-contextual-table",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Ember Table as a Contextual Component.",
   "keywords": [
     "ember-addon",

--- a/tests/integration/components/data-table-test.js
+++ b/tests/integration/components/data-table-test.js
@@ -290,3 +290,42 @@ test('custom row id prefix', function(assert) {
   assert.equal(this.$('#my-row-id-4>td:eq(0)').text().trim(), 'Aurélien');
 
 });
+
+
+
+
+test('dblclick on row triggers selectionchange action', function(assert) {
+  var selectionChangedCallCount = 0;
+
+  this.set('data', players);
+  this.on('selectionChanged', function(selectedRows){
+    if (selectionChangedCallCount === 0) {
+      assert.equal(selectedRows.length, 1, 'only one cell is selected');
+      assert.equal(selectedRows[0]['surname'], 'Muslera');
+    } else if (selectionChangedCallCount === 1) {
+      assert.equal(selectedRows.length, 0, 'selection cleared');
+    }
+
+    selectionChangedCallCount++;
+  });
+
+  this.render(hbs`
+    {{#data-table data=data showFooter=true selectionMode='multi' selectionChanged=(action 'selectionChanged') as |t|}}
+      {{t.selectionColumn}}
+      {{t.column propertyName='name' name='Name'}}
+      {{t.column propertyName='surname' name='Surname'}}
+      {{t.column propertyName='age' name='Age'}}
+      {{t.column propertyName='nationality' name='Nationality'}}
+    {{/data-table}}
+  `);
+
+  assert.equal(selectionChangedCallCount, 0);
+
+
+  this.$("tr:eq(3)")[0].dispatchEvent(new MouseEvent('dblclick', {}));
+  assert.equal(selectionChangedCallCount, 1);
+
+  this.$("tr:eq(3)")[0].dispatchEvent(new MouseEvent('dblclick', {}));
+  assert.equal(selectionChangedCallCount, 2);
+
+});

--- a/tests/integration/components/data-table-test.js
+++ b/tests/integration/components/data-table-test.js
@@ -2,13 +2,13 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-var sneijder = {name:'Wesley', surname:'Sneijder', age:32, nationality:'Dutch'};
-var podolski = {name:'Lukas', surname: 'Podolski', age:31, nationality:'German'};
-var muslera = {name:'Fernando', surname:'Muslera', age:30, nationality:'Uruguayan'};
-var selcuk = {name:'Selcuk', surname: 'Inan', age:31, nationality: 'Turkish'};
-var chedjou = {name:'Aurélien', surname:'Chedjou', age:31, nationality:'Cameroonian'};
+let sneijder = {name:'Wesley', surname:'Sneijder', age:32, nationality:'Dutch'};
+let podolski = {name:'Lukas', surname: 'Podolski', age:31, nationality:'German'};
+let muslera = {name:'Fernando', surname:'Muslera', age:30, nationality:'Uruguayan'};
+let selcuk = {name:'Selcuk', surname: 'Inan', age:31, nationality: 'Turkish'};
+let chedjou = {name:'Aurélien', surname:'Chedjou', age:31, nationality:'Cameroonian'};
 
-var players = [sneijder, podolski, muslera, selcuk, chedjou];
+let players = [sneijder, podolski, muslera, selcuk, chedjou];
 
 function assertPlayer(assert,index,player) {
   assert.equal(Ember.$(`tr:eq(${index})`).find("td:eq(1)").text().trim(), player['name']);
@@ -23,7 +23,7 @@ moduleForComponent('data-table', 'Integration | Component | data table', {
 });
 
 test('renders table and responds to selections and deselections', function(assert) {
-  var selectionCount = 0;
+  let selectionCount = 0;
 
   this.set('data', players);
   this.on('selectionChanged', function(selectedRows){
@@ -102,7 +102,7 @@ test('renders custom header and footer', function(assert) {
 
 
 test('clear selectedRows after data has changed', function(assert) {
-  var selectionCount = 0;
+  let selectionCount = 0;
   this.on('selectionChanged', function(selectedRows){
     selectionCount=selectedRows.length;
   });
@@ -156,8 +156,8 @@ test('clear selectedRows after data has changed', function(assert) {
 
 
 test('selectedRows are managed from user of data-table', function(assert) {
-  var parentSelectedRows = [players[0], players[2]];
-  var resultOfSelection = [];
+  let parentSelectedRows = [players[0], players[2]];
+  let resultOfSelection = [];
 
   this.set('data', players);
   this.set('parentSelectedRows', parentSelectedRows);
@@ -295,7 +295,7 @@ test('custom row id prefix', function(assert) {
 
 
 test('dblclick on row triggers selectionchange action', function(assert) {
-  var selectionChangedCallCount = 0;
+  let selectionChangedCallCount = 0;
 
   this.set('data', players);
   this.on('selectionChanged', function(selectedRows){

--- a/tests/integration/components/dt-selection-column-footer-test.js
+++ b/tests/integration/components/dt-selection-column-footer-test.js
@@ -44,7 +44,7 @@ test('renders in block form as button', function(assert) {
 
   this.render(hbs`
     {{#dt-selection-column-footer isSelected=selected selected=(action 'selected') deselected=(action 'deselected') as |col|}}
-        <button {{action col.change (if col.isSelected false true)}}>
+        <button onclick={{action col.change (if col.isSelected false true)}}>
           {{if col.isSelected 'Selected' 'Not Selected'}}-{{col.footer}}
         </button>
     {{/dt-selection-column-footer}}

--- a/tests/integration/components/dt-selection-column-footer-test.js
+++ b/tests/integration/components/dt-selection-column-footer-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-var selection, deselection;
+let selection, deselection;
 
 moduleForComponent('dt-selection-column-footer', 'Integration | Component | dt selection column footer', {
   integration: true,

--- a/tests/integration/components/dt-selection-column-header-test.js
+++ b/tests/integration/components/dt-selection-column-header-test.js
@@ -39,7 +39,7 @@ test('renders in block form as button', function(assert) {
 
   this.render(hbs`
     {{#dt-selection-column-header isSelected=selected selected=(action 'selected') deselected=(action 'deselected') as |col|}}
-        <button {{action col.change (if col.isSelected false true)}}>
+        <button onclick={{action col.change (if col.isSelected false true)}}>
           {{if col.isSelected 'Selected' 'Not Selected'}}-{{col.header}}
         </button>
     {{/dt-selection-column-header}}

--- a/tests/integration/components/dt-selection-column-test.js
+++ b/tests/integration/components/dt-selection-column-test.js
@@ -39,7 +39,7 @@ test('renders in block form as button', function(assert) {
 
   this.render(hbs`
     {{#dt-selection-column isRowSelected=selected rowSelected=(action 'selected') rowDeselected=(action 'deselected') as |col|}}
-        <button {{action col.change (if col.isRowSelected false true)}}>
+        <button onclick={{action col.change (if col.isRowSelected false true)}}>
           {{if col.isRowSelected 'Selected' 'Not Selected'}}-{{col.body}}
         </button>
     {{/dt-selection-column}}

--- a/tests/integration/components/dt-selection-column-test.js
+++ b/tests/integration/components/dt-selection-column-test.js
@@ -1,7 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-var selection, deselection;
+let selection, deselection;
 
 moduleForComponent('dt-selection-column', 'Integration | Component | dt selection column', {
   integration: true,


### PR DESCRIPTION
closes #24 

- all action helper usages have changed, action helpers are using as closure actions for now
- all `var` declaration turned to the `let`
- addon is ready for 1.10.0 version
